### PR TITLE
Feature/vagrant docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,14 @@ MAINTAINER colab oratory
 
 # the folder is called /vagrant for compatability with vagrant... should
 # probably be called /oratory
-RUN mkdir -p /vagrant/oratory/ /vagrant/lib
+RUN mkdir -p /vagrant/oratory/ /opt/node/lib/
 
-WORKDIR /vagrant/lib/
-ADD ./oratory/package.json /vagrant/lib/
+WORKDIR /opt/node/lib/
+ADD ./oratory/package.json /opt/node/lib/
 RUN npm install && \
     npm install -g supervisor
-ENV NODE_PATH /vagrant/lib/node_modules:$NODE_PATH
+ENV NODE_PATH /opt/node/lib/node_modules:$NODE_PATH
 
 WORKDIR /vagrant/oratory/
 EXPOSE 80
-
+CMD touch users.js && supervisor server.js

--- a/README.md
+++ b/README.md
@@ -3,6 +3,16 @@ app for inventory - used to explore mongo and angularJS - initial setup for free
 
 ## Quick Start
 
+### Vagrant + Docker
+No need to install Docker, Vagrant will do that for you!
+
+0. Install [Vagrant](https://www.vagrantup.com/downloads.html)
+1. `git clone https://github.com/colabprojects/oratory`
+2. `cd oratory`
+3. `vagrant up`
+4. wait...
+5. Go to [http://localhost:55657](http://localhost:55657) in your browser
+
 ### Docker
 
 0. Install Docker ([Linux](https://docs.docker.com/installation/), [Win/OSX](https://docker.com/toolbox/))
@@ -19,11 +29,11 @@ app for inventory - used to explore mongo and angularJS - initial setup for free
       [http://192.168.99.100:55657](http://192.168.99.100:55657)
 
 
-### Vagrant
+### Pure Vagrant
 
 0. Install [Vagrant](https://www.vagrantup.com/downloads.html)
 1. `git clone https://github.com/colabprojects/oratory`
 2. `cd oratory`
-3. `vagrant up`
+3. `vagrant up dockerless`
 4. wait...
 5. Go to [http://localhost:55657](http://localhost:55657) in your browser

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
 	config.vm.define "dockerless", autostart: false do |old|
-		old.vm.box = "ubuntu/trusty64"
+		old.vm.box = "ubuntu/vivid64"
 		
 		old.vm.network :forwarded_port, guest: 80, host: 55657
 		old.vm.network :forwarded_port, guest: 25, host: 55525
@@ -22,19 +22,21 @@ Vagrant.configure("2") do |config|
 	config.vm.define "web" do |web|
 		web.vm.synced_folder ".", "/vagrant", disabled: true
 		web.vm.synced_folder "./oratory", "/vagrant/oratory"
-		web.vm.provider "docker" do |docker|
-			docker.name = "web"
-			docker.build_dir = "."
-			docker.link("db:db")
-			docker.ports = ["55657:80"]
+		web.vm.provider "docker" do |d|
+			d.name = "web"
+			d.build_dir = "."
+			d.link("db:db")
+			d.ports = ["55657:80"]
+			d.vagrant_vagrantfile = "./Vagrantfile.proxy"
 		end
 	end
 
 	config.vm.define "db" do |db|
 		db.vm.synced_folder ".", "/vagrant", disabled: true
-		db.vm.provider "docker" do |docker|
-			docker.name = "db"
-			docker.image = "mongo:latest"
+		db.vm.provider "docker" do |d|
+			d.name = "db"
+			d.image = "mongo:latest"
+			d.vagrant_vagrantfile = "./Vagrantfile.proxy"
 		end
 	end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,28 +2,39 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-	config.vm.box = "ubuntu/trusty64"
-
-	# Create a forwarded port mapping which allows access to a specific port
-	# within the machine from a port on the host machine. In the example below,
-	# accessing "localhost:8080" will access port 80 on the guest machine.
-	config.vm.network :forwarded_port, guest: 80, host: 55657
-	config.vm.network :forwarded_port, guest: 25, host: 55525
-	config.vm.network :forwarded_port, guest: 465, host: 55465
-
-
-	#[WHY?] 1. Forward port 80 to host the static files on port 55656 (656 fairview school lane)
-	#       2. I am using 55,000's because Justin is amazing (also i think it is because high numbers won't fuck with your computer's goings-ons)
-	#       3. The forwarding of ports 25 and 465 is for mail (need a way for the smtp server to talk to the virtual machine)
+	config.vm.define "dockerless", autostart: false do |old|
+		old.vm.box = "ubuntu/trusty64"
+		
+		old.vm.network :forwarded_port, guest: 80, host: 55657
+		old.vm.network :forwarded_port, guest: 25, host: 55525
+		old.vm.network :forwarded_port, guest: 465, host: 55465
+		#[WHY?] 1. Forward port 80 to host the static files on port 55656 (656 fairview school lane)
+		#       2. I am using 55,000's because Justin is amazing (also i think it is because high numbers won't fuck with your computer's goings-ons)
+		#       3. The forwarding of ports 25 and 465 is for mail (need a way for the smtp server to talk to the virtual machine)
 
 
-	#[REMEMBER] sudo iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 465 -j REDIRECT --to-port 55465
+		#[REMEMBER] sudo iptables -t nat -A PREROUTING -i eth0 -p tcp --dport 465 -j REDIRECT --to-port 55465
+		
+		# Run provisioning scripts
+		old.vm.provision :shell, :path => "bootstrap.sh"
+	end
 
-	# Create a public network, which generally matched to bridged network.
-	# Bridged networks make the machine appear as another physical device on
-	# your network.
-	# config.vm.network :public_network
+	config.vm.define "web" do |web|
+		web.vm.synced_folder ".", "/vagrant", disabled: true
+		web.vm.synced_folder "./oratory", "/vagrant/oratory"
+		web.vm.provider "docker" do |docker|
+			docker.name = "web"
+			docker.build_dir = "."
+			docker.link("db:db")
+			docker.ports = ["55657:80"]
+		end
+	end
 
-	# Run provisioning scripts
-	config.vm.provision :shell, :path => "bootstrap.sh"
+	config.vm.define "db" do |db|
+		db.vm.synced_folder ".", "/vagrant", disabled: true
+		db.vm.provider "docker" do |docker|
+			docker.name = "db"
+			docker.image = "mongo:latest"
+		end
+	end
 end

--- a/Vagrantfile.proxy
+++ b/Vagrantfile.proxy
@@ -1,0 +1,14 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|  
+  config.vm.box = "ubuntu/vivid64"
+  config.vm.provision "docker"
+  # This is some magic so that vagrant is forced to re-ssh, and then docker commands will work
+  config.vm.provision "shell", inline:
+    "ps aux | grep 'sshd:' | awk '{print $2}' | xargs kill"
+
+  config.vm.network :forwarded_port, guest: 55657, host: 55657
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,6 @@ db:
   image: mongo:latest
 web:
   build: .
-  working_dir: /vagrant/oratory/
-  command: supervisor server.js
   volumes:
     - ./oratory/:/vagrant/oratory/
   ports:


### PR DESCRIPTION
Some docker love for us Windows/mac folks who can't run it natively. Uses vagrant to spin up a linux box to host things for us, and then spins up the Docker images on there. The cool thing is, if you are on linux it is smart enough to just bypass the proxy box and run the docker stuff natively!

The tricky part was getting all the port forwarding to work, so that I can just go to http://localhost:55657 like before.

This gives us the benefit of all using the same Dockerfile to spin up a dev instance. If this works well for everyone, we can probably get rid of `bootstrap.sh`. For now, you can `vagrant up dockerless` to spin up vagrant the old way.

With this, you should be able to just `vagrant up` and watch the magic happen.
